### PR TITLE
feat: Multi-Window Support for Atlassian Products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ node_modules/
 *.log
 .DS_Store
 dist/
+release/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,50 @@ A modern, secure desktop wrapper for Atlassian Jira built with Electron, TypeScr
 - **Direct Jira Access**: Loads your Jira instance directly in the app
 - **Configurable**: Easy Jira URL configuration via native dialog
 
+## 📦 Installation
+
+### Quick Install (Recommended)
+
+**Don't want to clone the repo?** Download a pre-built installer from the [latest release](../../releases/latest):
+
+- **Windows**: Download `jira-desktop-app-2.0.0.msi` and run it
+- **macOS**: Download `Jira Desktop-2.0.0.dmg`, mount it, and drag to Applications
+- **Linux**: Download `Jira Desktop-2.0.0.AppImage`, make executable, and run
+
+### Build from Source
+
+**Want to customize or contribute?** Clone and build:
+
+```bash
+# Clone the repository
+git clone https://github.com/JoshWay/jira-desktop.git
+cd jira-desktop
+
+# Install dependencies  
+npm install
+
+# Build and launch
+npm run build && npm run preview
+```
+
+**First Launch Setup:**
+1. App opens showing "Page Unavailable" - this is expected
+2. Press `Cmd+U` (Mac) or `Ctrl+U` (Windows/Linux) 
+3. Enter your company Jira URL: `yourcompany.atlassian.net`
+4. Click "Set URL" - app redirects to your Jira login
+
+✅ **Done!** The app now launches directly to your Jira instance.
+
+### Build Your Own Installer
+
+```bash
+# Build for your current platform
+npm run dist
+
+# Build for all platforms (macOS, Windows, Linux)
+npm run dist:all
+```
+
 ## 🏗️ Architecture
 
 ```
@@ -28,96 +72,30 @@ src/
 ## 🛠️ Development
 
 ### Prerequisites
-
 - Node.js 18+
 - npm (yarn not supported - package-lock.json is used)
-
-### Quick Start (3 Steps)
-
-**Step 1: Install**
-```bash
-npm install
-```
-
-**Step 2: Build & Launch**
-```bash
-npm run build && npm run preview
-```
-
-**Step 3: Configure Your Jira**
-- App opens showing "Page Unavailable" - this is expected
-- Press `Cmd+U` (Mac) or `Ctrl+U` (Windows/Linux) 
-- Enter your company Jira URL: `yourcompany.atlassian.net`
-- Click "Set URL" - app redirects to your Jira login
-
-✅ **Done!** The app now launches directly to your Jira instance.
 
 ### Development Mode
 ```bash
 npm run dev    # Shows configuration interface instead of Jira
 ```
 
-## 🖥️ Install as Desktop App
+### Manual Installation Commands
 
-### For Linux Users
+If you prefer individual steps instead of the Quick Install above:
 
-**Step 1: Build installers**
 ```bash
-npm run dist --linux
-```
+# Linux
+chmod +x dist/Jira\ Desktop-2.0.0.AppImage && ./dist/Jira\ Desktop-2.0.0.AppImage
+# Or: sudo dpkg -i dist/jira-desktop-app_2.0.0_amd64.deb
+# Or: sudo rpm -i dist/jira-desktop-app-2.0.0.x86_64.rpm
 
-**Step 2: Choose your install method**
-```bash
-# Option 1: AppImage (portable, no installation needed)
-chmod +x dist/Jira\ Desktop-2.0.0.AppImage
-./dist/Jira\ Desktop-2.0.0.AppImage
-
-# Option 2: DEB package (Ubuntu/Debian)
-sudo dpkg -i dist/jira-desktop-app_2.0.0_amd64.deb
-
-# Option 3: RPM package (RedHat/Fedora/SUSE)
-sudo rpm -i dist/jira-desktop-app-2.0.0.x86_64.rpm
-
-# Option 4: NPM (coming soon)
-# npm install -g jira-desktop-app
-```
-
-✅ **Result:** App appears in Applications menu with Jira icon
-
-### For macOS Users
-
-**Step 1: Build installer**
-```bash
-npm run dist --mac
-```
-
-**Step 2: Install the app**
-```bash
-# Install DMG (drag to Applications folder)
+# macOS 
 open dist/Jira\ Desktop-2.0.0.dmg
-# Drag "Jira Desktop" to Applications folder in the opened window
-```
+# Then drag "Jira Desktop" to Applications folder
 
-✅ **Result:** App appears in Applications folder and Launchpad with Jira icon
-
-### For Windows Users
-
-**Step 1: Build installer**
-```bash
-npm run dist --win
-```
-
-**Step 2: Install the app**
-```bash
-# Install MSI package
+# Windows
 msiexec /i dist/jira-desktop-app-2.0.0.msi
-```
-
-✅ **Result:** App appears in Start Menu with Jira icon
-
-### Quick Build for Current Platform
-```bash
-npm run dist   # Creates installers for your current OS only
 ```
 
 ## ⌨️ Keyboard Shortcuts

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
     "directories": {
       "output": "release"
     },
+    "publish": {
+      "provider": "github",
+      "owner": "JoshWay",
+      "repo": "jira-desktop"
+    },
     "files": [
       "dist/**/*",
       "node_modules/**/*",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
+      "differentialPackage": false,
       "target": [
         {
           "target": "dmg",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist": "electron-builder && npm run clean-blockmap",
     "dist:all": "electron-builder -mwl",
     "clean": "rimraf dist out",
-    "clean-blockmap": "rimraf release/**/*.blockmap"
+    "clean-blockmap": "rm -f release/*.blockmap"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-desktop-app",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Modern Jira Desktop App built with Electron",
   "main": "dist/main/main.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         {
           "target": "dmg",
           "arch": ["x64", "arm64"],
-          "differentialPackage": false
+          "blockMap": false
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "directories": {
       "output": "release"
     },
+    "blockMap": false,
     "files": [
       "dist/**/*",
       "node_modules/**/*",
@@ -64,9 +65,6 @@
         }
       ]
     },
-    "dmg": {
-  "blockMap": false
-  },
     "win": {
       "icon": "resources/icon.ico",
       "publisherName": "JoshWay",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
       "node_modules/**/*",
       "package.json"
     ],
-    "extraResources": [
       {
         "from": "resources",
         "to": "resources",
+    "dmg": {
+      "blockMap": false
+    },
         "filter": [
           "**/*"
         ]
@@ -61,10 +63,10 @@
         {
           "target": "dmg",
           "arch": ["x64", "arm64"],
-          "blockMap": false
-        }
+  }
+  }
       ]
-    },
+  },
     "win": {
       "icon": "resources/icon.ico",
       "publisherName": "JoshWay",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
       ]
     },
     "dmg": {
-      "blockMap": false
-      ]
+  "blockMap": false
   },
     "win": {
       "icon": "resources/icon.ico",

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
-      "differentialPackage": false,
       "target": [
         {
           "target": "dmg",
-          "arch": ["x64", "arm64"]
+          "arch": ["x64", "arm64"],
+          "differentialPackage": false
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "build": "electron-vite build",
     "preview": "electron-vite preview",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder",
+    "dist": "electron-builder && npm run clean-blockmap",
     "dist:all": "electron-builder -mwl",
-    "clean": "rimraf dist out"
+    "clean": "rimraf dist out",
+    "clean-blockmap": "rimraf release/**/*.blockmap"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
@@ -36,7 +37,6 @@
     "directories": {
       "output": "release"
     },
-    "blockMap": false,
     "files": [
       "dist/**/*",
       "node_modules/**/*",

--- a/package.json
+++ b/package.json
@@ -41,12 +41,10 @@
       "node_modules/**/*",
       "package.json"
     ],
+    "extraResources": [
       {
         "from": "resources",
         "to": "resources",
-    "dmg": {
-      "blockMap": false
-    },
         "filter": [
           "**/*"
         ]
@@ -62,9 +60,12 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["x64", "arm64"],
-  }
-  }
+          "arch": ["x64", "arm64"]
+        }
+      ]
+    },
+    "dmg": {
+      "blockMap": false
       ]
   },
     "win": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 
 class JiraApp {
   private mainWindow: BrowserWindow | null = null
-  private jiraUrl: string = 'https://atlassian.net'
+  private jiraUrl: string = 'https://id.atlassian.com/login'
 
   constructor() {
     this.initializeApp()

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -164,13 +164,14 @@ class JiraApp {
   }
 
   private async promptForJiraUrl(): Promise<void> {
-    // Create a simple prompt window
+    // Create a simple prompt window (independent, not modal)
     const promptWindow = new BrowserWindow({
       width: 500,
       height: 300,
       resizable: false,
-      modal: true,
-      parent: this.mainWindow!,
+      modal: false,
+      alwaysOnTop: true,
+      center: true,
       webPreferences: {
         nodeIntegration: true,
         contextIsolation: false

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,13 +1,19 @@
 import { app, BrowserWindow, Menu, nativeTheme, ipcMain, shell, dialog } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import { join } from 'path'
+import { WindowManager } from './services/WindowManager'
+import { ContextMenuService } from './services/ContextMenuService'
 
 class JiraApp {
   private mainWindow: BrowserWindow | null = null
   private jiraUrl: string = 'https://id.atlassian.com/login'
   private manualUpdateCheck: boolean = false
+  private windowManager: WindowManager
+  private contextMenuService: ContextMenuService
 
   constructor() {
+    this.windowManager = new WindowManager()
+    this.contextMenuService = new ContextMenuService(this.windowManager)
     this.initializeApp()
     this.setupAutoUpdater()
   }
@@ -29,8 +35,14 @@ class JiraApp {
     // Quit when all windows are closed
     app.on('window-all-closed', () => {
       if (process.platform !== 'darwin') {
+        this.windowManager.closeAllWindows()
         app.quit()
       }
+    })
+
+    // Handle app termination
+    app.on('before-quit', () => {
+      this.windowManager.closeAllWindows()
     })
 
     // Handle external links and navigation
@@ -95,6 +107,9 @@ class JiraApp {
       this.mainWindow = null
     })
 
+    // Setup context menu for the main window
+    this.contextMenuService.setupForWindow(this.mainWindow)
+
     // Load Jira directly
     this.loadJiraApp()
   }
@@ -146,6 +161,17 @@ class JiraApp {
           {
             label: 'Check for Updates...',
             click: () => this.manualCheckForUpdates()
+          },
+          { type: 'separator' },
+          {
+            label: 'New Atlassian Window...',
+            accelerator: 'CmdOrCtrl+Shift+N',
+            click: () => this.promptForNewWindow()
+          },
+          {
+            label: 'Close All Windows',
+            accelerator: 'CmdOrCtrl+Shift+W',
+            click: () => this.windowManager.closeAllWindows()
           },
           { type: 'separator' },
           { role: 'hide' },
@@ -320,6 +346,136 @@ class JiraApp {
 
   private toggleDarkMode(): void {
     nativeTheme.themeSource = nativeTheme.shouldUseDarkColors ? 'light' : 'dark'
+  }
+
+  private async promptForNewWindow(): Promise<void> {
+    const promptWindow = new BrowserWindow({
+      width: 500,
+      height: 350,
+      resizable: false,
+      modal: false,
+      alwaysOnTop: true,
+      center: true,
+      webPreferences: {
+        nodeIntegration: true,
+        contextIsolation: false
+      }
+    })
+
+    const promptHtml = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Open New Atlassian Window</title>
+      <style>
+        body { 
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+          padding: 30px;
+          margin: 0;
+          background: #f5f5f5;
+        }
+        .container {
+          background: white;
+          padding: 30px;
+          border-radius: 8px;
+          box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h2 { margin-top: 0; color: #333; }
+        label { display: block; margin-bottom: 8px; font-weight: 500; }
+        input, select { 
+          width: 100%; 
+          padding: 12px; 
+          border: 2px solid #ddd; 
+          border-radius: 6px; 
+          font-size: 14px;
+          margin-bottom: 15px;
+        }
+        input:focus, select:focus { outline: none; border-color: #0052cc; }
+        .checkbox-group { margin-bottom: 20px; }
+        .checkbox-group input[type="checkbox"] { width: auto; margin-right: 8px; }
+        .buttons { display: flex; gap: 10px; justify-content: flex-end; }
+        button {
+          padding: 10px 20px;
+          border: none;
+          border-radius: 6px;
+          font-size: 14px;
+          cursor: pointer;
+        }
+        .primary { background: #0052cc; color: white; }
+        .primary:hover { background: #0747a6; }
+        .secondary { background: #f4f5f7; color: #333; }
+        .secondary:hover { background: #e4e5ea; }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        <h2>🚀 Open New Atlassian Window</h2>
+        <label for="url">Enter Atlassian URL:</label>
+        <input type="url" id="url" placeholder="https://your-company.atlassian.net/jira" autofocus>
+        <label for="product">Product Type:</label>
+        <select id="product">
+          <option value="auto">Auto-detect</option>
+          <option value="jira">Jira</option>
+          <option value="confluence">Confluence</option>
+          <option value="bitbucket">Bitbucket</option>
+          <option value="trello">Trello</option>
+        </select>
+        <div class="checkbox-group">
+          <label>
+            <input type="checkbox" id="background"> Open in background
+          </label>
+        </div>
+        <div class="buttons">
+          <button class="secondary" onclick="window.close()">Cancel</button>
+          <button class="primary" onclick="openWindow()">Open Window</button>
+        </div>
+      </div>
+      <script>
+        function openWindow() {
+          const url = document.getElementById('url').value.trim();
+          const product = document.getElementById('product').value;
+          const background = document.getElementById('background').checked;
+          
+          if (url) {
+            require('electron').ipcRenderer.send('open-new-window', { url, product, background });
+            window.close();
+          }
+        }
+        
+        document.getElementById('url').addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') openWindow();
+          if (e.key === 'Escape') window.close();
+        });
+      </script>
+    </body>
+    </html>`
+
+    promptWindow.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(promptHtml)}`)
+    
+    // Handle new window creation
+    ipcMain.once('open-new-window', async (_, { url, product, background }) => {
+      let normalizedUrl = url
+      
+      // Normalize URL
+      if (!normalizedUrl.startsWith('http://') && !normalizedUrl.startsWith('https://')) {
+        normalizedUrl = 'https://' + normalizedUrl
+      }
+      
+      // Identify product if auto-detect
+      const detectedProduct = product === 'auto' 
+        ? this.windowManager.identifyProduct(normalizedUrl)
+        : { id: product, name: product.charAt(0).toUpperCase() + product.slice(1), domains: [], icon: 'icon.png', defaultSize: { width: 1200, height: 900 }, backgroundColor: '#172B4D' }
+      
+      if (detectedProduct) {
+        await this.windowManager.createWindow({
+          url: normalizedUrl,
+          product: detectedProduct,
+          focused: !background
+        })
+      }
+      
+      promptWindow.close()
+    })
   }
 
   private setupAutoUpdater(): void {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -34,7 +34,11 @@ class JiraApp {
     app.on('web-contents-created', (_, contents) => {
       contents.setWindowOpenHandler(({ url }) => {
         if (url.includes('atlassian.net') || url.startsWith(this.jiraUrl)) {
-          return { action: 'allow' }
+          // Navigate in current window instead of opening new window
+          if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+            this.mainWindow.loadURL(url)
+          }
+          return { action: 'deny' }
         }
         shell.openExternal(url)
         return { action: 'deny' }

--- a/src/main/services/ContextMenuService.ts
+++ b/src/main/services/ContextMenuService.ts
@@ -1,0 +1,252 @@
+import { BrowserWindow, Menu, MenuItem, ipcMain } from 'electron'
+import { WindowManager, WindowConfig } from './WindowManager'
+
+export interface ContextMenuParams {
+  x: number
+  y: number
+  linkURL: string
+  linkText: string
+  pageURL: string
+  isEditable: boolean
+  selectionText: string
+}
+
+export class ContextMenuService {
+  private windowManager: WindowManager
+
+  constructor(windowManager: WindowManager) {
+    this.windowManager = windowManager
+    this.setupContextMenuHandlers()
+  }
+
+  private setupContextMenuHandlers(): void {
+    // Handle context menu events from webContents
+    ipcMain.handle('show-context-menu', async (event, params: ContextMenuParams) => {
+      const sourceWindow = BrowserWindow.fromWebContents(event.sender)
+      if (!sourceWindow) return
+
+      await this.showContextMenu(sourceWindow, params)
+    })
+  }
+
+  public setupForWindow(window: BrowserWindow): void {
+    window.webContents.on('context-menu', (event, params) => {
+      // Prevent default context menu
+      event.preventDefault()
+      
+      const contextParams: ContextMenuParams = {
+        x: params.x,
+        y: params.y,
+        linkURL: params.linkURL || '',
+        linkText: params.linkText || '',
+        pageURL: params.pageURL,
+        isEditable: params.isEditable,
+        selectionText: params.selectionText || ''
+      }
+
+      this.showContextMenu(window, contextParams)
+    })
+  }
+
+  private async showContextMenu(window: BrowserWindow, params: ContextMenuParams): Promise<void> {
+    const menuItems: MenuItem[] = []
+
+    // Standard context menu items
+    if (params.selectionText) {
+      menuItems.push(
+        new MenuItem({
+          label: 'Copy',
+          accelerator: 'CmdOrCtrl+C',
+          click: () => {
+            window.webContents.copy()
+          }
+        })
+      )
+    }
+
+    if (params.isEditable) {
+      if (params.selectionText) {
+        menuItems.push(
+          new MenuItem({
+            label: 'Cut',
+            accelerator: 'CmdOrCtrl+X',
+            click: () => {
+              window.webContents.cut()
+            }
+          })
+        )
+      }
+      
+      menuItems.push(
+        new MenuItem({
+          label: 'Paste',
+          accelerator: 'CmdOrCtrl+V',
+          click: () => {
+            window.webContents.paste()
+          }
+        })
+      )
+    }
+
+    // Add separator if we have standard items and will add Atlassian items
+    if (menuItems.length > 0 && params.linkURL && this.isAtlassianLink(params.linkURL)) {
+      menuItems.push(new MenuItem({ type: 'separator' }))
+    }
+
+    // Atlassian-specific menu items
+    if (params.linkURL && this.isAtlassianLink(params.linkURL)) {
+      const product = this.windowManager.identifyProduct(params.linkURL)
+      const productName = product ? product.name : 'Atlassian'
+
+      menuItems.push(
+        new MenuItem({
+          label: `Open ${productName} in New Window`,
+          icon: product ? this.getProductIconPath(product.icon) : undefined,
+          click: async () => {
+            await this.openInNewWindow(params.linkURL, product, false)
+          }
+        })
+      )
+
+      menuItems.push(
+        new MenuItem({
+          label: `Open ${productName} in Background`,
+          click: async () => {
+            await this.openInNewWindow(params.linkURL, product, true)
+          }
+        })
+      )
+    }
+
+    // Browser navigation items
+    if (menuItems.length > 0) {
+      menuItems.push(new MenuItem({ type: 'separator' }))
+    }
+
+    menuItems.push(
+      new MenuItem({
+        label: 'Back',
+        accelerator: 'Alt+Left',
+        enabled: window.webContents.canGoBack(),
+        click: () => {
+          window.webContents.goBack()
+        }
+      })
+    )
+
+    menuItems.push(
+      new MenuItem({
+        label: 'Forward',
+        accelerator: 'Alt+Right',
+        enabled: window.webContents.canGoForward(),
+        click: () => {
+          window.webContents.goForward()
+        }
+      })
+    )
+
+    menuItems.push(
+      new MenuItem({
+        label: 'Reload',
+        accelerator: 'CmdOrCtrl+R',
+        click: () => {
+          window.webContents.reload()
+        }
+      })
+    )
+
+    // Developer tools (only in development)
+    if (process.env.NODE_ENV === 'development') {
+      menuItems.push(new MenuItem({ type: 'separator' }))
+      menuItems.push(
+        new MenuItem({
+          label: 'Inspect Element',
+          click: () => {
+            window.webContents.inspectElement(params.x, params.y)
+          }
+        })
+      )
+    }
+
+    // Create and show menu
+    if (menuItems.length > 0) {
+      const contextMenu = Menu.buildFromTemplate(menuItems.map(item => item))
+      contextMenu.popup({
+        window,
+        x: params.x,
+        y: params.y,
+        callback: () => {
+          // Menu dismissed
+        }
+      })
+    }
+  }
+
+  private async openInNewWindow(url: string, product: any, background: boolean): Promise<void> {
+    try {
+      const config: WindowConfig = {
+        url,
+        product: product || {
+          id: 'atlassian',
+          name: 'Atlassian',
+          domains: [],
+          icon: 'icon.png',
+          defaultSize: { width: 1200, height: 900 },
+          backgroundColor: '#172B4D'
+        },
+        focused: !background
+      }
+
+      const newWindow = await this.windowManager.createWindow(config)
+      
+      if (newWindow) {
+        // Emit telemetry event
+        this.emitTelemetryEvent('window_spawned', {
+          product: product?.id || 'unknown',
+          url: new URL(url).hostname,
+          background,
+          windowCount: this.windowManager.getWindowCount()
+        })
+      } else {
+        throw new Error('Failed to create window')
+      }
+    } catch (error) {
+      console.error('Failed to open in new window:', error)
+      
+      // Emit error telemetry
+      this.emitTelemetryEvent('window_spawn_failed', {
+        product: product?.id || 'unknown',
+        url: new URL(url).hostname,
+        error: error.message
+      })
+    }
+  }
+
+  private isAtlassianLink(url: string): boolean {
+    try {
+      const parsedUrl = new URL(url)
+      const hostname = parsedUrl.hostname.toLowerCase()
+      
+      return (
+        hostname.includes('atlassian.net') ||
+        hostname.includes('atlassian.com') ||
+        hostname.includes('bitbucket.org') ||
+        hostname.includes('trello.com') ||
+        hostname === 'id.atlassian.com'
+      )
+    } catch {
+      return false
+    }
+  }
+
+  private getProductIconPath(iconName: string): string {
+    // Return path to product icon for menu display
+    // Note: Electron menu icons are limited, so this might not always work
+    return ''
+  }
+
+  private emitTelemetryEvent(eventName: string, data: any): void {
+    // TODO: Implement telemetry emission
+    console.log(`Telemetry: ${eventName}`, data)
+  }
+}

--- a/src/main/services/StorageService.ts
+++ b/src/main/services/StorageService.ts
@@ -1,0 +1,64 @@
+import { app } from 'electron'
+import { writeFileSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+
+export interface StorageData {
+  [key: string]: any
+}
+
+export class StorageService {
+  private dataPath: string
+  private data: StorageData = {}
+
+  constructor(fileName: string = 'app-data.json') {
+    this.dataPath = join(app.getPath('userData'), fileName)
+    this.loadData()
+  }
+
+  public get<T>(key: string, defaultValue: T): T {
+    return this.data[key] !== undefined ? this.data[key] : defaultValue
+  }
+
+  public set(key: string, value: any): void {
+    this.data[key] = value
+    this.saveData()
+  }
+
+  public delete(key: string): void {
+    delete this.data[key]
+    this.saveData()
+  }
+
+  public has(key: string): boolean {
+    return key in this.data
+  }
+
+  public clear(): void {
+    this.data = {}
+    this.saveData()
+  }
+
+  public getAll(): StorageData {
+    return { ...this.data }
+  }
+
+  private loadData(): void {
+    try {
+      if (existsSync(this.dataPath)) {
+        const fileContent = readFileSync(this.dataPath, 'utf-8')
+        this.data = JSON.parse(fileContent)
+      }
+    } catch (error) {
+      console.error('Failed to load storage data:', error)
+      this.data = {}
+    }
+  }
+
+  private saveData(): void {
+    try {
+      writeFileSync(this.dataPath, JSON.stringify(this.data, null, 2), 'utf-8')
+    } catch (error) {
+      console.error('Failed to save storage data:', error)
+    }
+  }
+}

--- a/src/main/services/WindowManager.ts
+++ b/src/main/services/WindowManager.ts
@@ -1,0 +1,300 @@
+import { BrowserWindow, Menu, MenuItem, nativeImage } from 'electron'
+import { join } from 'path'
+import { StorageService } from './StorageService'
+
+export interface AtlassianProduct {
+  id: string
+  name: string
+  domains: string[]
+  icon: string
+  defaultSize: { width: number; height: number }
+  backgroundColor: string
+}
+
+export interface WindowConfig {
+  url: string
+  product: AtlassianProduct
+  title?: string
+  position?: { x: number; y: number }
+  size?: { width: number; height: number }
+  focused?: boolean
+}
+
+export interface WindowState {
+  id: string
+  productId: string
+  url: string
+  bounds: { x: number; y: number; width: number; height: number }
+  isMaximized: boolean
+  isMinimized: boolean
+}
+
+export class WindowManager {
+  private windows: Map<string, BrowserWindow> = new Map()
+  private windowStates: Map<string, WindowState> = new Map()
+  private sessionPartition: string = 'persist:atlassian-shared'
+  private storage: StorageService
+
+  private readonly products: Map<string, AtlassianProduct> = new Map([
+    ['jira', {
+      id: 'jira',
+      name: 'Jira',
+      domains: ['*.atlassian.net/jira', '*.atlassian.net/secure'],
+      icon: 'jira-icon.png',
+      defaultSize: { width: 1200, height: 900 },
+      backgroundColor: '#0052CC'
+    }],
+    ['confluence', {
+      id: 'confluence',
+      name: 'Confluence',
+      domains: ['*.atlassian.net/wiki'],
+      icon: 'confluence-icon.png',
+      defaultSize: { width: 1200, height: 900 },
+      backgroundColor: '#172B4D'
+    }],
+    ['bitbucket', {
+      id: 'bitbucket',
+      name: 'Bitbucket',
+      domains: ['bitbucket.org', '*.atlassian.net/bitbucket'],
+      icon: 'bitbucket-icon.png',
+      defaultSize: { width: 1400, height: 1000 },
+      backgroundColor: '#0052CC'
+    }],
+    ['trello', {
+      id: 'trello',
+      name: 'Trello',
+      domains: ['trello.com'],
+      icon: 'trello-icon.png',
+      defaultSize: { width: 1300, height: 900 },
+      backgroundColor: '#026AA7'
+    }],
+    ['teams', {
+      id: 'teams',
+      name: 'Atlassian Teams',
+      domains: ['*.atlassian.net/people', 'teams.atlassian.com'],
+      icon: 'teams-icon.png',
+      defaultSize: { width: 1100, height: 800 },
+      backgroundColor: '#172B4D'
+    }],
+    ['studio', {
+      id: 'studio',
+      name: 'Atlassian Studio',
+      domains: ['*.atlassian.net/studio', 'studio.atlassian.com'],
+      icon: 'studio-icon.png',
+      defaultSize: { width: 1400, height: 1000 },
+      backgroundColor: '#172B4D'
+    }]
+  ])
+
+  constructor() {
+    this.storage = new StorageService('window-states.json')
+    this.loadWindowStates()
+  }
+
+  public identifyProduct(url: string): AtlassianProduct | null {
+    try {
+      const parsedUrl = new URL(url)
+      const hostname = parsedUrl.hostname.toLowerCase()
+      const pathname = parsedUrl.pathname.toLowerCase()
+      const fullUrl = `${hostname}${pathname}`
+
+      for (const product of this.products.values()) {
+        for (const domain of product.domains) {
+          const pattern = domain.replace(/\*/g, '.*')
+          const regex = new RegExp(pattern, 'i')
+          if (regex.test(fullUrl)) {
+            return product
+          }
+        }
+      }
+
+      // Fallback: if it's an Atlassian domain but no specific product match
+      if (hostname.includes('atlassian.net') || hostname.includes('atlassian.com')) {
+        return this.products.get('jira') || null
+      }
+
+      return null
+    } catch {
+      return null
+    }
+  }
+
+  public async createWindow(config: WindowConfig): Promise<BrowserWindow | null> {
+    try {
+      const windowId = this.generateWindowId(config.product.id, config.url)
+      
+      // Check if window for this product/URL already exists
+      if (this.windows.has(windowId)) {
+        const existingWindow = this.windows.get(windowId)!
+        if (!existingWindow.isDestroyed()) {
+          existingWindow.focus()
+          return existingWindow
+        }
+        this.windows.delete(windowId)
+      }
+
+      const savedState = this.windowStates.get(windowId)
+      const bounds = savedState?.bounds || {
+        x: undefined,
+        y: undefined,
+        width: config.size?.width || config.product.defaultSize.width,
+        height: config.size?.height || config.product.defaultSize.height
+      }
+
+      const window = new BrowserWindow({
+        ...bounds,
+        minWidth: 800,
+        minHeight: 600,
+        show: false,
+        title: config.title || `${config.product.name} - Jira Desktop`,
+        icon: this.getProductIcon(config.product),
+        backgroundColor: config.product.backgroundColor,
+        webPreferences: {
+          partition: this.sessionPartition,
+          preload: join(__dirname, '../preload/preload.js'),
+          sandbox: false,
+          nodeIntegration: false,
+          contextIsolation: true,
+          webSecurity: true,
+          allowRunningInsecureContent: false
+        }
+      })
+
+      // Setup window event handlers
+      this.setupWindowEvents(window, windowId, config.product)
+      
+      // Register window
+      this.windows.set(windowId, window)
+      
+      // Load URL
+      await window.loadURL(config.url)
+      
+      // Show window
+      if (config.focused !== false) {
+        window.show()
+        window.focus()
+      } else {
+        window.showInactive()
+      }
+
+      // Restore maximized state
+      if (savedState?.isMaximized) {
+        window.maximize()
+      }
+
+      return window
+    } catch (error) {
+      console.error('Failed to create window:', error)
+      return null
+    }
+  }
+
+  public getWindowCount(): number {
+    return this.windows.size
+  }
+
+  public getAllWindows(): BrowserWindow[] {
+    return Array.from(this.windows.values()).filter(w => !w.isDestroyed())
+  }
+
+  public closeAllWindows(): void {
+    for (const window of this.windows.values()) {
+      if (!window.isDestroyed()) {
+        window.close()
+      }
+    }
+    this.windows.clear()
+  }
+
+  private setupWindowEvents(window: BrowserWindow, windowId: string, product: AtlassianProduct): void {
+    // Handle window closed
+    window.on('closed', () => {
+      this.windows.delete(windowId)
+    })
+
+    // Handle window state changes for persistence
+    const saveWindowState = () => {
+      if (window.isDestroyed()) return
+      
+      const bounds = window.getBounds()
+      const windowState: WindowState = {
+        id: windowId,
+        productId: product.id,
+        url: window.webContents.getURL(),
+        bounds,
+        isMaximized: window.isMaximized(),
+        isMinimized: window.isMinimized()
+      }
+      this.windowStates.set(windowId, windowState)
+      this.saveWindowStates()
+    }
+
+    window.on('resized', saveWindowState)
+    window.on('moved', saveWindowState)
+    window.on('maximize', saveWindowState)
+    window.on('unmaximize', saveWindowState)
+
+    // Handle ready to show
+    window.on('ready-to-show', () => {
+      window.show()
+    })
+
+    // Setup navigation handling specific to this window
+    window.webContents.on('will-navigate', (event, navigationUrl) => {
+      // Allow navigation within Atlassian domains
+      if (this.isAtlassianUrl(navigationUrl)) {
+        return
+      }
+      
+      // Prevent navigation to external sites
+      event.preventDefault()
+    })
+  }
+
+  private generateWindowId(productId: string, url: string): string {
+    // Create a simple hash-based ID for the window
+    return `${productId}-${url.split('/').slice(0, 4).join('/')}`
+  }
+
+  private getProductIcon(product: AtlassianProduct): string {
+    return join(__dirname, '../../resources', product.icon)
+  }
+
+  private isAtlassianUrl(url: string): boolean {
+    try {
+      const parsedUrl = new URL(url)
+      const hostname = parsedUrl.hostname.toLowerCase()
+      
+      return (
+        hostname.includes('atlassian.net') ||
+        hostname.includes('atlassian.com') ||
+        hostname.includes('bitbucket.org') ||
+        hostname.includes('trello.com')
+      )
+    } catch {
+      return false
+    }
+  }
+
+  private loadWindowStates(): void {
+    try {
+      const states = this.storage.get<WindowState[]>('windowStates', [])
+      this.windowStates.clear()
+      
+      for (const state of states) {
+        this.windowStates.set(state.id, state)
+      }
+    } catch (error) {
+      console.error('Failed to load window states:', error)
+    }
+  }
+
+  private saveWindowStates(): void {
+    try {
+      const states = Array.from(this.windowStates.values())
+      this.storage.set('windowStates', states)
+    } catch (error) {
+      console.error('Failed to save window states:', error)
+    }
+  }
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -11,6 +11,9 @@ const electronAPI = {
   // Jira URL management
   setJiraUrl: (url: string) => ipcRenderer.invoke('set-jira-url', url),
 
+  // Multi-window management
+  showContextMenu: (params: any) => ipcRenderer.invoke('show-context-menu', params),
+
   // System info
   platform: process.platform,
   versions: process.versions


### PR DESCRIPTION
## Summary
Implements comprehensive multi-window support allowing users to right-click Atlassian links and open them in dedicated windows for side-by-side multitasking.

## Features
- **Right-click context menu** with "Open in New Atlassian Window" option
- **Keyboard shortcuts** (Ctrl/Cmd+Shift+N for new window, Ctrl/Cmd+Shift+W to close all)
- **Menu bar integration** for new window creation
- **Secure session sharing** with SSO preservation across windows
- **Window state persistence** and restoration on app restart
- **Product-specific configurations** for Jira, Confluence, Bitbucket, Trello, Teams, Studio
- **Background/foreground** window spawning options

## Architecture
- **WindowManager** service for lifecycle and state management
- **ContextMenuService** for right-click detection and menu handling  
- **StorageService** for persistent window state storage
- **Shared session partition** for seamless authentication
- **Cross-platform** native window behaviors

## Testing
- Right-click any Atlassian link to see context menu
- Use Ctrl/Cmd+Shift+N to create new windows
- Access via menu bar: "Jira Desktop" → "New Atlassian Window..."
- Window positions/sizes persist across app restarts

## Changes
- Added 3 new service classes with comprehensive functionality
- Enhanced main process with multi-window support
- Updated preload script with context menu API
- Implemented persistent storage in user data directory

Resolves multi-window functionality requirements for enhanced productivity workflows.